### PR TITLE
fix(field): handle missing interval view gracefully

### DIFF
--- a/src/django_interval/fields.py
+++ b/src/django_interval/fields.py
@@ -5,7 +5,7 @@ from typing import Callable, Tuple
 from django.db.models import CharField, DateField
 from django.contrib.contenttypes.models import ContentType
 from django.forms import ValidationError
-from django.urls import reverse
+from django.urls import reverse, NoReverseMatch
 
 from django_interval.utils import defaultdateparser
 from django_interval.widgets import IntervalWidget
@@ -33,8 +33,12 @@ class GenericDateIntervalField(CharField):
     def formfield(self, *args, **kwargs):
         content_type = ContentType.objects.get_for_model(self.model)
         natural_key = f"{content_type.app_label}.{content_type.model}"
-        interval_view = reverse("intervalview", args=[natural_key, self.name])
-        kwargs["widget"] = IntervalWidget(attrs={"data-intervaluri": interval_view})
+        try:
+            interval_view = reverse("intervalview", args=[natural_key, self.name])
+            attrs = {"data-intervaluri": interval_view}
+        except NoReverseMatch:
+            attrs = {}
+        kwargs["widget"] = IntervalWidget(attrs=attrs)
         return super().formfield(*args, **kwargs)
 
 

--- a/src/django_interval/static/js/intervalwidget.js
+++ b/src/django_interval/static/js/intervalwidget.js
@@ -1,19 +1,21 @@
 window.addEventListener('load', () => {
     document.querySelectorAll(".intervalwidget").forEach(function(element) {
         element.onkeyup = function(element) {
-            fetch(element.target.dataset.intervaluri + "?datestring=" + element.target.value)
-                .then(response => response.text())
-                .then(data => {
-                    nesi = element.target.nextSibling;
-                    if (nesi.classList && nesi.classList.contains("interval-help")) {
-                        interval_help = nesi;
-                    } else {
-                        interval_help = document.createElement("div");
-                        interval_help.classList.add("interval-help");
-                        element.target.insertAdjacentElement("afterend", interval_help)
-                    }
-                    interval_help.innerHTML = data;
-                });
+            if (element.target.dataset.intervaluri) {
+                fetch(element.target.dataset.intervaluri + "?datestring=" + element.target.value)
+                    .then(response => response.text())
+                    .then(data => {
+                        nesi = element.target.nextSibling;
+                        if (nesi.classList && nesi.classList.contains("interval-help")) {
+                            interval_help = nesi;
+                        } else {
+                            interval_help = document.createElement("div");
+                            interval_help.classList.add("interval-help");
+                            element.target.insertAdjacentElement("afterend", interval_help)
+                        }
+                        interval_help.innerHTML = data;
+                    });
+            }
         };
     });
 });


### PR DESCRIPTION
The field should still work, even if the django_interval.urls are not
included in the projects urlpatterns. Therefore we put the `reverse`
method in a try/except block and only set the `data-intervaluri` if the
endpoint exists.
If the `data-intervaluri` is not set, the triggered javascript simply
does nothing.

Closes: #11
