### PR TITLE
build: set backend to hatchling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,3 +12,7 @@ dependencies = [
 dev = [
     "ruff>=0.8.2",
 ]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"


### PR DESCRIPTION
The uv build backend is still in preview, so we use the hatchling
backend for now.

Closes: #12 