### PR TITLE
fix(fields): remove autocreated attribute on the autocreated fields

### DIFF
--- a/src/django_interval/fields.py
+++ b/src/django_interval/fields.py
@@ -21,7 +21,7 @@ class GenericDateIntervalField(CharField):
     """
 
     def add_generated_date_field(self, cls, name):
-        date_field = DateField(editable=False, blank=True, null=True, auto_created=True)
+        date_field = DateField(editable=False, blank=True, null=True)
         cls.add_to_class(name, date_field)
         setattr(self, f"_{name}", date_field)
 


### PR DESCRIPTION
reverses #bd50343 as this attribute prevents the fields from being updated via form submits as the field gets excluded from the form

closes #58